### PR TITLE
ColorGenerator now uses the hue from options, if provided

### DIFF
--- a/lib/color-generator.rb
+++ b/lib/color-generator.rb
@@ -12,9 +12,14 @@ class ColorGenerator
   # @option opts [Float,Integer] :value value in the interval [0, 1], sets the
   #   color representation to HSV
   # @option opts [Integer] :seed seed for the pseudorandom number generator
+  # @option opts [Float,Integer] :hue hue to use as the start in the interval [0, 1]
   def initialize(opts = {})
-    srand(opts[:seed]) if opts.key?(:seed)
-    @hue = rand
+    if opts.key?(:hue)
+      @hue = opts[:hue]
+    else
+      srand(opts[:seed]) if opts.key?(:seed)
+      @hue = rand
+    end
     @saturation = opts[:saturation].to_f
     if opts.has_key? :lightness
       @mode = :HSL

--- a/spec/color-generator_spec.rb
+++ b/spec/color-generator_spec.rb
@@ -21,4 +21,10 @@ describe ColorGenerator do
       value.should <= 255
     end
   end
+
+  it 'should use the provided hue' do
+    generator = ColorGenerator.new(:saturation => 0.3, :value => 1.0, :hue => 0.5)
+    generator.create_hex.should == 'ffe9b3'
+    generator.hue.should == 0.1180339887498949
+  end
 end


### PR DESCRIPTION
Could be useful to store the state of the generator, let say in a database for later reuse.
